### PR TITLE
Duplicate `my $item` was causing a warning to be thrown

### DIFF
--- a/lib/Data/Dump/Color.pm
+++ b/lib/Data/Dump/Color.pm
@@ -56,7 +56,7 @@ sub _col {
     return $str unless $COLOR;
 
     my $ansi = '';
-    my $item = $ct_obj->get_item_color($item);
+    $item = $ct_obj->get_item_color($item);
     if (defined $item) {
         $ansi = ColorThemeUtil::ANSI::item_color_to_ansi($item);
     }


### PR DESCRIPTION
We might want to consider `use warnings` in this to catch this sort of thing in the future?