### PR TITLE
BUGIX: Potential fix for #13

### DIFF
--- a/lib/Data/Dump/Color.pm
+++ b/lib/Data/Dump/Color.pm
@@ -59,10 +59,15 @@ sub max {
 }
 
 sub _col {
+    require Module::Load::Util;
     require ColorThemeUtil::ANSI;
+
     my ($item, $str) = @_;
 
     return $str unless $COLOR;
+
+    local $ct_obj = Module::Load::Util::instantiate_class_with_optional_args(
+        {ns_prefixes=>['ColorTheme::Data::Dump::Color','ColorTheme','']}, $COLOR_THEME);
 
     my $ansi = '';
     $item = $ct_obj->get_item_color($item);

--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use 5.010;
 use strict;
@@ -19,8 +19,30 @@ subtest dump => sub {
 }));
 };
 
+my $orig = $Data::Dump::Color::COLOR;
+$Data::Dump::Color::COLOR = 1; # Force color on for these tests
+
+is(sub_has_errors('dd')  , "", "dd() runs");
+is(sub_has_errors('ddx') , "", "ddx() runs");
+is(sub_has_errors('dump'), "", "dump() runs");
+
+$Data::Dump::Color::COLOR = $orig;
+
 DONE_TESTING:
 done_testing;
+
+# Returns any syntax error if found, or "" on success
+sub sub_has_errors {
+	no strict "refs";
+	my $sub_name = shift();
+
+	eval { &$sub_name(); };
+
+	my $err = $@;
+	$err =~ s/\s+$//;
+
+	return $err;
+}
 
 __END__
 # disabled for now


### PR DESCRIPTION
After a `git bisect` I determined the first bad commit was: d11e36e5ac8e0fd1d2e03741593a3bf1d4cb74f3

Looks like the module references `$ct_obj` before it's instantiated? I just copied the instantiation from another sub and it now runs fine. I also verified it passed all the tests.